### PR TITLE
1 time

### DIFF
--- a/Lib/Modules/visionModeling/preprocessedObservation.cpp
+++ b/Lib/Modules/visionModeling/preprocessedObservation.cpp
@@ -309,7 +309,8 @@ bool preprocessedObservation::getTwoMatchRate(const MatrixWrapper::ColumnVector 
 		if (((1 <= x_temp) && (x_temp <= col)) && ((1 <= y_temp) && (y_temp <= row)))
 			realweight = realweight + lut_graph[y_temp - 1][x_temp - 1][theta_temp];
 	}
-
+    realweight = realweight/point_size;
+    observationMatchRate=realweight;
 	return true;
 }
 


### PR DESCRIPTION
point_size总点数，是line_point vector 的大小。当vector中的元素超过表的范围，则忽略不计。
realweight = realweight/point_size; 
 observationMatchRate=realweight; 